### PR TITLE
Stage paranext-core's dev packages before installing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,13 +36,6 @@ jobs:
             paranext-core/package-lock.json
           node-version-file: extension-repo/package.json
 
-      # `stage-dev-packages` needs pnpm whenever the pinned editor revision has no committed
-      # build to copy; it is a no-op the rest of the time.
-      - name: Install PNPM
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10
-
       # Our editor `file:` dependency points into core's gitignored `dev-packages/staging/`, which
       # only core's `preinstall` creates — and the core install below runs `--ignore-scripts`. npm
       # links a missing `file:` target silently, so skipping this leaves a broken symlink.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,20 @@ jobs:
             paranext-core/package-lock.json
           node-version-file: extension-repo/package.json
 
+      # `stage-dev-packages` needs pnpm whenever the pinned editor revision has no committed
+      # build to copy; it is a no-op the rest of the time.
+      - name: Install PNPM
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+
+      # Our editor `file:` dependency points into core's gitignored `dev-packages/staging/`, which
+      # only core's `preinstall` creates — and the core install below runs `--ignore-scripts`. npm
+      # links a missing `file:` target silently, so skipping this leaves a broken symlink.
+      - name: Stage paranext-core's dev packages
+        working-directory: paranext-core
+        run: node .erb/scripts/stage-dev-packages.ts
+
       - name: Install extension dependencies
         working-directory: extension-repo
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,20 @@ jobs:
             paranext-core/package-lock.json
           node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
 
+      # `stage-dev-packages` needs pnpm whenever the pinned editor revision has no committed
+      # build to copy; it is a no-op the rest of the time.
+      - name: Install PNPM
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+
+      # Our editor `file:` dependency points into core's gitignored `dev-packages/staging/`, which
+      # only core's `preinstall` creates — and the core install below runs `--ignore-scripts`. npm
+      # links a missing `file:` target silently, so skipping this leaves a broken symlink.
+      - name: Stage paranext-core's dev packages
+        working-directory: paranext-core
+        run: node .erb/scripts/stage-dev-packages.ts
+
       - name: Install packages
         run: |
           npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,13 +73,6 @@ jobs:
             paranext-core/package-lock.json
           node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
 
-      # `stage-dev-packages` needs pnpm whenever the pinned editor revision has no committed
-      # build to copy; it is a no-op the rest of the time.
-      - name: Install PNPM
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10
-
       # Our editor `file:` dependency points into core's gitignored `dev-packages/staging/`, which
       # only core's `preinstall` creates — and the core install below runs `--ignore-scripts`. npm
       # links a missing `file:` target silently, so skipping this leaves a broken symlink.


### PR DESCRIPTION
paranext-core#2745 changes how the Scripture editor is consumed: it is no longer installed from the npm registry, but staged by core's `preinstall` into the gitignored `dev-packages/staging/`, with `lib/platform-bible-react` and `lib/platform-bible-utils` depending on those folders through `file:` specifiers.

The core install in this repo's workflows uses `--ignore-scripts`, so core's `preinstall` never runs and those folders never exist. npm links a missing `file:` target without complaining, so `npm ci` exits 0 and leaves a dangling symlink where the editor should be. This repo does not import the editor itself, but PBR imports it in 28 files and PBU in 10, so it surfaces later as an unresolved module during lint or typecheck, blamed on the wrong thing.

This adds one explicit staging step before either install. It is plain Node with no npm lifecycle, and a copy rather than a build whenever the pinned editor revision carries its committed `dist/`. pnpm is set up alongside because staging falls back to building when it does not.

**Draft until [paranext-core#2745](https://github.com/paranext/paranext-core/pull/2745) merges** — `.erb/scripts/stage-dev-packages.ts` does not exist on core `main` yet, so CI here cannot pass before then.

Matches the same change already made in `paratext-bible-extensions` and `paratext-assistant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqqozB7YdhQFin63R2gBpL

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-extension-sneeze-board/22)
<!-- Reviewable:end -->
